### PR TITLE
format license statement in a more legible way

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,16 +72,15 @@ This project was originally based on [an answer on StackExchange](http://unix.st
 
 ## License
 
-Copyright 2015 Stefan Heule
+> Copyright (c) 2015, Stefan Heule
 
-Licensed under the Apache License, Version 2.0 (the "License");
+> Licensed under the **Apache License, Version 2.0** (the "License");
 you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+You may obtain a copy of the License at:
 
-    http://www.apache.org/licenses/LICENSE-2.0
+>    http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
+> Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+See the License for the specific language governing permissions and limitations under the License.


### PR DESCRIPTION
- use blockquote markup (this groups the whole statement into a block,
  and makes the link clickable rather than marked as code
- mark the license name as bold
- use the (c) symbol for easier visual identification
  (and as customary with copyright notices)
- re-wrap the disclaimer at the bottom using semantic linefeeds:
  http://rhodesmill.org/brandon/2012/one-sentence-per-line/
